### PR TITLE
Section5-2_Q&Aサイトを作ろう

### DIFF
--- a/app/assets/javascripts/answers.coffee
+++ b/app/assets/javascripts/answers.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/questions.coffee
+++ b/app/assets/javascripts/questions.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/answers.scss
+++ b/app/assets/stylesheets/answers.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the answers controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/questions.scss
+++ b/app/assets/stylesheets/questions.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the questions controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,0 +1,74 @@
+class AnswersController < ApplicationController
+  before_action :set_answer, only: [:show, :edit, :update, :destroy]
+
+  # GET /answers
+  # GET /answers.json
+  def index
+    @answers = Answer.all
+  end
+
+  # GET /answers/1
+  # GET /answers/1.json
+  def show
+  end
+
+  # GET /answers/new
+  def new
+    @answer = Answer.new
+  end
+
+  # GET /answers/1/edit
+  def edit
+  end
+
+  # POST /answers
+  # POST /answers.json
+  def create
+    @answer = Answer.new(answer_params)
+
+    respond_to do |format|
+      if @answer.save
+        format.html { redirect_to @answer, notice: 'Answer was successfully created.' }
+        format.json { render :show, status: :created, location: @answer }
+      else
+        format.html { render :new }
+        format.json { render json: @answer.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /answers/1
+  # PATCH/PUT /answers/1.json
+  def update
+    respond_to do |format|
+      if @answer.update(answer_params)
+        format.html { redirect_to @answer, notice: 'Answer was successfully updated.' }
+        format.json { render :show, status: :ok, location: @answer }
+      else
+        format.html { render :edit }
+        format.json { render json: @answer.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /answers/1
+  # DELETE /answers/1.json
+  def destroy
+    @answer.destroy
+    respond_to do |format|
+      format.html { redirect_to answers_url, notice: 'Answer was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_answer
+      @answer = Answer.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def answer_params
+      params.require(:answer).permit(:question_id, :content, :name)
+    end
+end

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -37,7 +37,7 @@ class AnswersController < ApplicationController
           q.finished = true
           q.save
         end
-        format.html { redirect_to questions_path, notice: 'Answer was successfully created.' }
+        format.html { redirect_to question_path(@answer.question_id), notice: 'Answer was successfully created.' }
         format.json { render :show, status: :created, location: @answer }
       else
         format.html { render :new }

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -4,12 +4,13 @@ class AnswersController < ApplicationController
   # GET /answers
   # GET /answers.json
   def index
-    @answers = Answer.all
+    redirect_to questions_path
   end
 
   # GET /answers/1
   # GET /answers/1.json
   def show
+    redirect_to questions_path
   end
 
   # GET /answers/new
@@ -19,6 +20,7 @@ class AnswersController < ApplicationController
 
   # GET /answers/1/edit
   def edit
+    redirect_to questions_path
   end
 
   # POST /answers
@@ -40,25 +42,13 @@ class AnswersController < ApplicationController
   # PATCH/PUT /answers/1
   # PATCH/PUT /answers/1.json
   def update
-    respond_to do |format|
-      if @answer.update(answer_params)
-        format.html { redirect_to @answer, notice: 'Answer was successfully updated.' }
-        format.json { render :show, status: :ok, location: @answer }
-      else
-        format.html { render :edit }
-        format.json { render json: @answer.errors, status: :unprocessable_entity }
-      end
-    end
+    redirect_to questions_path
   end
 
   # DELETE /answers/1
   # DELETE /answers/1.json
   def destroy
-    @answer.destroy
-    respond_to do |format|
-      format.html { redirect_to answers_url, notice: 'Answer was successfully destroyed.' }
-      format.json { head :no_content }
-    end
+    redirect_to questions_path
   end
 
   private

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -26,11 +26,18 @@ class AnswersController < ApplicationController
   # POST /answers
   # POST /answers.json
   def create
+    end_counter = 10
     @answer = Answer.new(answer_params)
 
     respond_to do |format|
       if @answer.save
-        format.html { redirect_to @answer, notice: 'Answer was successfully created.' }
+        num = Answer.where('question_id = ?', @answer.question_id).count
+        if num >= end_counter
+          q = Question.find(@answer.question_id)
+          q.finished = true
+          q.save
+        end
+        format.html { redirect_to questions_path, notice: 'Answer was successfully created.' }
         format.json { render :show, status: :created, location: @answer }
       else
         format.html { render :new }

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -15,7 +15,7 @@ class AnswersController < ApplicationController
 
   # GET /answers/new
   def new
-    @answer = Answer.new
+    redirect_to questions_path
   end
 
   # GET /answers/1/edit

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,0 +1,74 @@
+class QuestionsController < ApplicationController
+  before_action :set_question, only: [:show, :edit, :update, :destroy]
+
+  # GET /questions
+  # GET /questions.json
+  def index
+    @questions = Question.all
+  end
+
+  # GET /questions/1
+  # GET /questions/1.json
+  def show
+  end
+
+  # GET /questions/new
+  def new
+    @question = Question.new
+  end
+
+  # GET /questions/1/edit
+  def edit
+  end
+
+  # POST /questions
+  # POST /questions.json
+  def create
+    @question = Question.new(question_params)
+
+    respond_to do |format|
+      if @question.save
+        format.html { redirect_to @question, notice: 'Question was successfully created.' }
+        format.json { render :show, status: :created, location: @question }
+      else
+        format.html { render :new }
+        format.json { render json: @question.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /questions/1
+  # PATCH/PUT /questions/1.json
+  def update
+    respond_to do |format|
+      if @question.update(question_params)
+        format.html { redirect_to @question, notice: 'Question was successfully updated.' }
+        format.json { render :show, status: :ok, location: @question }
+      else
+        format.html { render :edit }
+        format.json { render json: @question.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /questions/1
+  # DELETE /questions/1.json
+  def destroy
+    @question.destroy
+    respond_to do |format|
+      format.html { redirect_to questions_url, notice: 'Question was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_question
+      @question = Question.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def question_params
+      params.require(:question).permit(:title, :content, :name, :finished)
+    end
+end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,6 +1,6 @@
 class QuestionsController < ApplicationController
   before_action :set_question, only: [:show, :edit, :update, :destroy]
-  layout 'questions'
+#  layout 'questions'
 
   # GET /questions
   # GET /questions.json
@@ -32,7 +32,7 @@ class QuestionsController < ApplicationController
 
     respond_to do |format|
       if @question.save
-        format.html { redirect_to @question, notice: 'Question was successfully created.' }
+        format.html { redirect_to questions_path, notice: 'Question was successfully created.' }
         format.json { render :show, status: :created, location: @question }
       else
         format.html { render :new }

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -22,6 +22,7 @@ class QuestionsController < ApplicationController
 
   # GET /questions/1/edit
   def edit
+    redirect_to questions_path
   end
 
   # POST /questions
@@ -43,25 +44,13 @@ class QuestionsController < ApplicationController
   # PATCH/PUT /questions/1
   # PATCH/PUT /questions/1.json
   def update
-    respond_to do |format|
-      if @question.update(question_params)
-        format.html { redirect_to @question, notice: 'Question was successfully updated.' }
-        format.json { render :show, status: :ok, location: @question }
-      else
-        format.html { render :edit }
-        format.json { render json: @question.errors, status: :unprocessable_entity }
-      end
-    end
+    redirect_to questions_path
   end
 
   # DELETE /questions/1
   # DELETE /questions/1.json
   def destroy
-    @question.destroy
-    respond_to do |format|
-      format.html { redirect_to questions_url, notice: 'Question was successfully destroyed.' }
-      format.json { head :no_content }
-    end
+   redirect_to questions_path
   end
 
   private

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -11,6 +11,8 @@ class QuestionsController < ApplicationController
   # GET /questions/1
   # GET /questions/1.json
   def show
+    @answer = Answer.new
+    @answer.question_id = params[:id]
   end
 
   # GET /questions/new

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,6 +1,5 @@
 class QuestionsController < ApplicationController
   before_action :set_question, only: [:show, :edit, :update, :destroy]
-#  layout 'questions'
 
   # GET /questions
   # GET /questions.json

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -29,7 +29,7 @@ class QuestionsController < ApplicationController
   # POST /questions.json
   def create
     @question = Question.new(question_params)
-
+    
     respond_to do |format|
       if @question.save
         format.html { redirect_to questions_path, notice: 'Question was successfully created.' }

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -5,7 +5,7 @@ class QuestionsController < ApplicationController
   # GET /questions
   # GET /questions.json
   def index
-    @questions = Question.all
+    @questions = Question.all.order created_at: :desc
   end
 
   # GET /questions/1

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,5 +1,6 @@
 class QuestionsController < ApplicationController
   before_action :set_question, only: [:show, :edit, :update, :destroy]
+  layout 'questions'
 
   # GET /questions
   # GET /questions.json

--- a/app/helpers/answers_helper.rb
+++ b/app/helpers/answers_helper.rb
@@ -1,0 +1,2 @@
+module AnswersHelper
+end

--- a/app/helpers/questions_helper.rb
+++ b/app/helpers/questions_helper.rb
@@ -1,0 +1,2 @@
+module QuestionsHelper
+end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,0 +1,2 @@
+class Answer < ApplicationRecord
+end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,2 +1,5 @@
 class Answer < ApplicationRecord
+  belongs_to :question
+  
+  validates :content, :name, presence: true
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,0 +1,2 @@
+class Question < ApplicationRecord
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,2 +1,5 @@
 class Question < ApplicationRecord
+  has_many :answers
+  
+  validates :content, :name, presence: true
 end

--- a/app/views/answers/_answer.json.jbuilder
+++ b/app/views/answers/_answer.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! answer, :id, :question_id, :content, :name, :created_at, :updated_at
+json.url answer_url(answer, format: :json)

--- a/app/views/answers/_form.html.erb
+++ b/app/views/answers/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_for(answer) do |f| %>
+  <% if answer.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(answer.errors.count, "error") %> prohibited this answer from being saved:</h2>
+
+      <ul>
+      <% answer.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :question_id %>
+    <%= f.number_field :question_id %>
+  </div>
+
+  <div class="field">
+    <%= f.label :content %>
+    <%= f.text_area :content %>
+  </div>
+
+  <div class="field">
+    <%= f.label :name %>
+    <%= f.text_area :name %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/answers/_form.html.erb
+++ b/app/views/answers/_form.html.erb
@@ -11,21 +11,20 @@
     </div>
   <% end %>
 
-  <div class="field">
-    <%= f.label :question_id %>
-    <%= f.number_field :question_id %>
-  </div>
-
-  <div class="field">
-    <%= f.label :content %>
-    <%= f.text_area :content %>
-  </div>
-
+  <%= f.hidden_field :question_id, { value: answer.question_id } %>
+  
   <div class="field">
     <%= f.label :name %>
     <%= f.text_area :name %>
   </div>
 
+  <div class="field">
+    <%= f.label :content %>
+    <%= f.text_area :content, { cols: 40, rows: 5 } %>
+  </div>
+
+  <br>
+  
   <div class="actions">
     <%= f.submit %>
   </div>

--- a/app/views/answers/edit.html.erb
+++ b/app/views/answers/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Answer</h1>
+
+<%= render 'form', answer: @answer %>
+
+<%= link_to 'Show', @answer %> |
+<%= link_to 'Back', answers_path %>

--- a/app/views/answers/index.html.erb
+++ b/app/views/answers/index.html.erb
@@ -1,0 +1,31 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Answers</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Question</th>
+      <th>Content</th>
+      <th>Name</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @answers.each do |answer| %>
+      <tr>
+        <td><%= answer.question_id %></td>
+        <td><%= answer.content %></td>
+        <td><%= answer.name %></td>
+        <td><%= link_to 'Show', answer %></td>
+        <td><%= link_to 'Edit', edit_answer_path(answer) %></td>
+        <td><%= link_to 'Destroy', answer, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Answer', new_answer_path %>

--- a/app/views/answers/index.json.jbuilder
+++ b/app/views/answers/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @answers, partial: 'answers/answer', as: :answer

--- a/app/views/answers/new.html.erb
+++ b/app/views/answers/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Answer</h1>
+
+<%= render 'form', answer: @answer %>
+
+<%= link_to 'Back', answers_path %>

--- a/app/views/answers/new.html.erb
+++ b/app/views/answers/new.html.erb
@@ -1,4 +1,21 @@
-<h1>New Answer</h1>
+<p id="notice"><%= notice %></p>
+
+<h1>質問と回答</h1>
+
+<div class='question'>
+  <h2 class='title'>
+    <%= @answer.question.title %>
+  </h2>
+  <p class='content'>
+    <%= @answer.question.content %>
+  </p>
+  <p class='q_name'>
+    <%= @answer.question.name %>
+  </p>
+  <span class="<%= @answer.question.finished ? 'finished' : 'not_finished' %>">
+    <%= @answer.question.finished ? '終了' : '受付中' %>
+  </span>
+</div>
 
 <%= render 'form', answer: @answer %>
 

--- a/app/views/answers/show.html.erb
+++ b/app/views/answers/show.html.erb
@@ -1,0 +1,19 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Question:</strong>
+  <%= @answer.question_id %>
+</p>
+
+<p>
+  <strong>Content:</strong>
+  <%= @answer.content %>
+</p>
+
+<p>
+  <strong>Name:</strong>
+  <%= @answer.name %>
+</p>
+
+<%= link_to 'Edit', edit_answer_path(@answer) %> |
+<%= link_to 'Back', answers_path %>

--- a/app/views/answers/show.json.jbuilder
+++ b/app/views/answers/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "answers/answer", answer: @answer

--- a/app/views/layouts/questions.html.erb
+++ b/app/views/layouts/questions.html.erb
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>RailsApp</title>
+    <%= csrf_meta_tags %>
+    
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+  </head>
+
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -1,0 +1,37 @@
+<%= form_for(question) do |f| %>
+  <% if question.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(question.errors.count, "error") %> prohibited this question from being saved:</h2>
+
+      <ul>
+      <% question.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :title %>
+    <%= f.text_area :title %>
+  </div>
+
+  <div class="field">
+    <%= f.label :content %>
+    <%= f.text_area :content %>
+  </div>
+
+  <div class="field">
+    <%= f.label :name %>
+    <%= f.text_area :name %>
+  </div>
+
+  <div class="field">
+    <%= f.label :finished %>
+    <%= f.check_box :finished %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -18,7 +18,7 @@
 
   <div class="field">
     <%= f.label :content %>
-    <%= f.text_area :content %>
+    <%= f.text_area :content, { cols: 40, rows: 10 } %>
   </div>
 
   <div class="field">
@@ -26,10 +26,7 @@
     <%= f.text_area :name %>
   </div>
 
-  <div class="field">
-    <%= f.label :finished %>
-    <%= f.check_box :finished %>
-  </div>
+  <%= f.hidden_field :finished, { value: false } %>
 
   <div class="actions">
     <%= f.submit %>

--- a/app/views/questions/_form2.html.erb
+++ b/app/views/questions/_form2.html.erb
@@ -1,0 +1,31 @@
+<%= form_for(answer) do |f| %>
+  <% if answer.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(answer.errors.count, "error") %> prohibited this question from being saved:</h2>
+
+      <ul>
+      <% answer.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <%= f.hidden_field :qustion_id, { value: answer.question_id } %>
+
+  <div class="field">
+    <%= f.label :name %>
+    <%= f.text_area :name %>
+  </div>
+
+  <div class="field">
+    <%= f.label :content %>
+    <%= f.text_area :content, { cols: 40, rows: 5 } %>
+  </div>
+
+  <br>
+
+  <div class="actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/questions/_form2.html.erb
+++ b/app/views/questions/_form2.html.erb
@@ -11,8 +11,8 @@
     </div>
   <% end %>
 
-  <%= f.hidden_field :qustion_id, { value: answer.question_id } %>
-
+  <%= f.hidden_field :question_id, { value: answer.question_id } %>
+  
   <div class="field">
     <%= f.label :name %>
     <%= f.text_area :name %>

--- a/app/views/questions/_question.json.jbuilder
+++ b/app/views/questions/_question.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! question, :id, :title, :content, :name, :finished, :created_at, :updated_at
+json.url question_url(question, format: :json)

--- a/app/views/questions/edit.html.erb
+++ b/app/views/questions/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Question</h1>
+
+<%= render 'form', question: @question %>
+
+<%= link_to 'Show', @question %> |
+<%= link_to 'Back', questions_path %>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,0 +1,33 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Questions</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th>Content</th>
+      <th>Name</th>
+      <th>Finished</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @questions.each do |question| %>
+      <tr>
+        <td><%= question.title %></td>
+        <td><%= question.content %></td>
+        <td><%= question.name %></td>
+        <td><%= question.finished %></td>
+        <td><%= link_to 'Show', question %></td>
+        <td><%= link_to 'Edit', edit_question_path(question) %></td>
+        <td><%= link_to 'Destroy', question, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Question', new_question_path %>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,15 +1,13 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Questions</h1>
+<h1>質問リスト</h1>
 
-<table>
+<table class='qlist'>
   <thead>
     <tr>
       <th>Title</th>
-      <th>Content</th>
-      <th>Name</th>
       <th>Finished</th>
-      <th colspan="3"></th>
+      <th></th>
     </tr>
   </thead>
 
@@ -17,12 +15,8 @@
     <% @questions.each do |question| %>
       <tr>
         <td><%= question.title %></td>
-        <td><%= question.content %></td>
-        <td><%= question.name %></td>
-        <td><%= question.finished %></td>
+        <td><%= question.finished ? '終了' : '受付中' %></td>
         <td><%= link_to 'Show', question %></td>
-        <td><%= link_to 'Edit', edit_question_path(question) %></td>
-        <td><%= link_to 'Destroy', question, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>
@@ -30,4 +24,4 @@
 
 <br>
 
-<%= link_to 'New Question', new_question_path %>
+<%= link_to '※新たに質問する', new_question_path %>

--- a/app/views/questions/index.json.jbuilder
+++ b/app/views/questions/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @questions, partial: 'questions/question', as: :question

--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Question</h1>
+
+<%= render 'form', question: @question %>
+
+<%= link_to 'Back', questions_path %>

--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -1,4 +1,4 @@
-<h1>New Question</h1>
+<h1>新しい質問</h1>
 
 <%= render 'form', question: @question %>
 

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,0 +1,24 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Title:</strong>
+  <%= @question.title %>
+</p>
+
+<p>
+  <strong>Content:</strong>
+  <%= @question.content %>
+</p>
+
+<p>
+  <strong>Name:</strong>
+  <%= @question.name %>
+</p>
+
+<p>
+  <strong>Finished:</strong>
+  <%= @question.finished %>
+</p>
+
+<%= link_to 'Edit', edit_question_path(@question) %> |
+<%= link_to 'Back', questions_path %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,24 +1,36 @@
 <p id="notice"><%= notice %></p>
 
-<p>
-  <strong>Title:</strong>
-  <%= @question.title %>
-</p>
+<h1>質問と回答</h1>
 
-<p>
-  <strong>Content:</strong>
-  <%= @question.content %>
-</p>
+<div class='question'>
+  <h2 class='title'>
+    <%= @question.title %>
+  </h2>
+  <p class='content'>
+    <%= @question.content %>
+  </p>
+  <p class='q_name'>
+    <%= @question.name %>
+  </p>
+  <span class="<%= @question.finished ? 'finished' : 'not_finished' %>">
+    <%= @question.finished ? '終了' : '受付中' %>
+  </span>
+</div>
 
-<p>
-  <strong>Name:</strong>
-  <%= @question.name %>
-</p>
+<% if @question.finished? == false %>
+  <div class='answer_form'>
+    <%= render 'form2', answer: @answer %>
+  </div>
+<% end %>
 
-<p>
-  <strong>Finished:</strong>
-  <%= @question.finished %>
-</p>
+<h2>※これまで寄せられた回答</h2>
 
-<%= link_to 'Edit', edit_question_path(@question) %> |
-<%= link_to 'Back', questions_path %>
+<% if @question.answer.count == 0 %>
+  <p class='answer'>まだありません。</p>
+<% else %>
+  <% @question.answer.reverse_each do |re| %>
+    <p class='answer'>
+      <%= re.content + '（' + re.name + '）' %>
+    </p>
+  <% end %>
+<% end %>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -25,10 +25,10 @@
 
 <h2>※これまで寄せられた回答</h2>
 
-<% if @question.answer.count == 0 %>
+<% if @question.answers.count == 0 %>
   <p class='answer'>まだありません。</p>
 <% else %>
-  <% @question.answer.reverse_each do |re| %>
+  <% @question.answers.reverse_each do |re| %>
     <p class='answer'>
       <%= re.content + '（' + re.name + '）' %>
     </p>

--- a/app/views/questions/show.json.jbuilder
+++ b/app/views/questions/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "questions/question", question: @question

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
 
+  resources :questions
   resources :mycontacts
   get 'blogs', to: 'blogs#index'
   get 'blogs/:id/genre', to: 'blogs#genre'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
 
+  resources :answers
   resources :questions
   resources :mycontacts
   get 'blogs', to: 'blogs#index'

--- a/db/migrate/20181024110325_create_questions.rb
+++ b/db/migrate/20181024110325_create_questions.rb
@@ -1,0 +1,12 @@
+class CreateQuestions < ActiveRecord::Migration[5.0]
+  def change
+    create_table :questions do |t|
+      t.text :title
+      t.text :content
+      t.text :name
+      t.boolean :finished
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20181024110522_create_answers.rb
+++ b/db/migrate/20181024110522_create_answers.rb
@@ -1,0 +1,11 @@
+class CreateAnswers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :answers do |t|
+      t.integer :question_id
+      t.text :content
+      t.text :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181024100741) do
+ActiveRecord::Schema.define(version: 20181024110522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "answers", force: :cascade do |t|
+    t.integer  "question_id"
+    t.text     "content"
+    t.text     "name"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
 
   create_table "blogconfigs", force: :cascade do |t|
     t.text     "title"
@@ -70,6 +78,15 @@ ActiveRecord::Schema.define(version: 20181024100741) do
     t.text     "name"
     t.integer  "age"
     t.text     "mail"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "questions", force: :cascade do |t|
+    t.text     "title"
+    t.text     "content"
+    t.text     "name"
+    t.boolean  "finished"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/test/controllers/answers_controller_test.rb
+++ b/test/controllers/answers_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class AnswersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @answer = answers(:one)
+  end
+
+  test "should get index" do
+    get answers_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_answer_url
+    assert_response :success
+  end
+
+  test "should create answer" do
+    assert_difference('Answer.count') do
+      post answers_url, params: { answer: { content: @answer.content, name: @answer.name, question_id: @answer.question_id } }
+    end
+
+    assert_redirected_to answer_url(Answer.last)
+  end
+
+  test "should show answer" do
+    get answer_url(@answer)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_answer_url(@answer)
+    assert_response :success
+  end
+
+  test "should update answer" do
+    patch answer_url(@answer), params: { answer: { content: @answer.content, name: @answer.name, question_id: @answer.question_id } }
+    assert_redirected_to answer_url(@answer)
+  end
+
+  test "should destroy answer" do
+    assert_difference('Answer.count', -1) do
+      delete answer_url(@answer)
+    end
+
+    assert_redirected_to answers_url
+  end
+end

--- a/test/controllers/questions_controller_test.rb
+++ b/test/controllers/questions_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class QuestionsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @question = questions(:one)
+  end
+
+  test "should get index" do
+    get questions_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_question_url
+    assert_response :success
+  end
+
+  test "should create question" do
+    assert_difference('Question.count') do
+      post questions_url, params: { question: { content: @question.content, finished: @question.finished, name: @question.name, title: @question.title } }
+    end
+
+    assert_redirected_to question_url(Question.last)
+  end
+
+  test "should show question" do
+    get question_url(@question)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_question_url(@question)
+    assert_response :success
+  end
+
+  test "should update question" do
+    patch question_url(@question), params: { question: { content: @question.content, finished: @question.finished, name: @question.name, title: @question.title } }
+    assert_redirected_to question_url(@question)
+  end
+
+  test "should destroy question" do
+    assert_difference('Question.count', -1) do
+      delete question_url(@question)
+    end
+
+    assert_redirected_to questions_url
+  end
+end

--- a/test/fixtures/answers.yml
+++ b/test/fixtures/answers.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  question_id: 1
+  content: MyText
+  name: MyText
+
+two:
+  question_id: 1
+  content: MyText
+  name: MyText

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  title: MyText
+  content: MyText
+  name: MyText
+  finished: false
+
+two:
+  title: MyText
+  content: MyText
+  name: MyText
+  finished: false

--- a/test/models/answer_test.rb
+++ b/test/models/answer_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AnswerTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/question_test.rb
+++ b/test/models/question_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class QuestionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
やりたかったこと
---
- p.354~375
- Scaffoldを使ってQ&Aサイトを作成する
└質問リスト一覧
└回答ができる詳細ページ
└回答が10個溜まると回答受付終了する機能

やったこと
----
- `rails g scaffold question title:text content:text name:text finished:boolean`の実行
- `rails g scaffold answer question_id:integer content:text name:text`の実行
- `rails db:migrate`の実行
- question, answerモデルにバリデーションとアソシエーションを追加
- 質問一覧画面(/questions/index)、質問新規投稿画面(/questions/new)の修正
- 質問新規投稿画面(/questions/new)のフォームテンプレートを修正
- 質問と回答リストの詳細画面(/questions/show)の修正
- 上記詳細画面で回答を受け付けるフォームテンプレートを修正
- questionsコントローラーの使用しないアクションに質問一覧画面へのリダイレクトを設定
- answerコントローラーの使用しないアクションに質問一覧画面へのリダイレクトを設定
- 質問への回答数に応じて処理を分ける(回答数10以上であればQuestions.finishedをtrue)処理を追加したanswers#createアクションを作成

動作確認方法
---
- herokuURL
https://tyonyumon-railsapp.herokuapp.com/questions

- [x] /questionsにアクセスし、質問一覧画面が表示される
- [x] 上記一覧画面でステータスが表示される
- [x] 上記一覧画面から新規投稿画面へ遷移、新規登録が行える
- [x] 上記一覧画面から詳細画面へ遷移できる
- [x] 詳細画面で受付中であれば回答でき、回答一覧に反映される
- [x] 詳細画面で受付中でなければ回答一覧のみが表示される

その他
---
- 不要なアクションへのルーティング削除ではなく、本の記載通り一旦リダイレクトで対応いたしました！
- レイアウトを整えることはしていないです…すいません！
